### PR TITLE
fix: TUIログメッセージの二重表示を修正 (#19)

### DIFF
--- a/internal/tui/app/app.go
+++ b/internal/tui/app/app.go
@@ -149,6 +149,7 @@ func (m MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tui.LogOutputMsg:
 		m.dashboard.AppendLog(msg.Text)
+		return m, nil
 
 	case tui.ForwardToggleMsg:
 		cmds = append(cmds, m.toggleForward(msg.RuleName))

--- a/internal/tui/app/app_test.go
+++ b/internal/tui/app/app_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ousiassllc/moleport/internal/core"
 	"github.com/ousiassllc/moleport/internal/ipc/protocol"
+	"github.com/ousiassllc/moleport/internal/tui"
 )
 
 func TestHostInfoToSSHHost(t *testing.T) {
@@ -155,6 +156,19 @@ func TestParseConnectionState(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("parseConnectionState(%q) = %v, want %v", tt.input, got, tt.want)
 		}
+	}
+}
+
+func TestLogOutputMsgNotDuplicated(t *testing.T) {
+	m := NewMainModel(nil, "test")
+	m.dashboard.SetSize(80, 24)
+
+	msg := tui.LogOutputMsg{Text: "テストメッセージ"}
+	result, _ := m.Update(msg)
+	updated := result.(MainModel)
+
+	if got := updated.dashboard.LogLineCount(); got != 1 {
+		t.Errorf("LogLineCount() = %d, want 1 (log message was duplicated)", got)
 	}
 }
 

--- a/internal/tui/organisms/logpanel.go
+++ b/internal/tui/organisms/logpanel.go
@@ -30,6 +30,11 @@ func (p *LogPanel) AppendOutput(text string) {
 	}
 }
 
+// OutputLen は出力バッファの行数を返す。
+func (p LogPanel) OutputLen() int {
+	return len(p.output)
+}
+
 // SetSize はパネルのサイズを設定する。
 func (p *LogPanel) SetSize(width, height int) {
 	p.width = width

--- a/internal/tui/pages/dashboard.go
+++ b/internal/tui/pages/dashboard.go
@@ -208,6 +208,11 @@ func (d *DashboardPage) AppendLog(text string) {
 	d.log.AppendOutput(text)
 }
 
+// LogLineCount はログ出力の行数を返す。
+func (d DashboardPage) LogLineCount() int {
+	return d.log.OutputLen()
+}
+
 // FocusedPane は現在のフォーカスペインを返す。
 func (d DashboardPage) FocusedPane() tui.FocusPane {
 	return d.focusedPane


### PR DESCRIPTION
## Summary

- TUIログパネルで全メッセージが2行ずつ重複表示されるバグを修正
- `app.go` の `LogOutputMsg` case に `return m, nil` を追加し、`dashboard.Update()` への二重転送を防止
- 回帰テスト `TestLogOutputMsgNotDuplicated` を追加

## Root Cause

`app.go:Update()` で `LogOutputMsg` を処理した後 `return` していなかったため、switch 終了後の `m.dashboard.Update(msg)` にも同じメッセージが転送され、`dashboard.go:Update()` 内でも `LogOutputMsg` をハンドルしてログが二重追加されていた。

## Changes

| File | Change |
|------|--------|
| `internal/tui/app/app.go` | `LogOutputMsg` case に `return m, nil` を追加 |
| `internal/tui/app/app_test.go` | 回帰テスト追加 |
| `internal/tui/organisms/logpanel.go` | テスト用 `OutputLen()` アクセサ追加 |
| `internal/tui/pages/dashboard.go` | テスト用 `LogLineCount()` アクセサ追加 |

## Test Plan

- [x] 回帰テスト: `TestLogOutputMsgNotDuplicated` が修正前に失敗(count=2)、修正後にパス(count=1)
- [x] 全テスト通過 (`go test ./...`)
- [x] race detector テスト通過 (`go test -race ./...`)
- [x] golangci-lint 通過
- [ ] TUI で操作し、ログが1行ずつ表示されることを手動確認

Closes #19