### PR TITLE
fix: TUIからforward.startで認証コールバックなしパスに落ちる (#20)

### DIFF
--- a/internal/core/forward.go
+++ b/internal/core/forward.go
@@ -17,7 +17,8 @@ type ForwardManager interface {
 
 	// StartForward は指定ルールのポートフォワーディングを開始する。
 	// 必要に応じて SSH 接続を確立し、リスナーを作成して accept ループを起動する。
-	StartForward(ruleName string) error
+	// cb が非 nil の場合、SSH 接続にクレデンシャルコールバックを使用する。
+	StartForward(ruleName string, cb CredentialCallback) error
 
 	// StopForward は指定ルールのフォワーディングセッションを停止する。
 	// アクティブでない場合はエラーなしで何もしない。

--- a/internal/core/forward/events_test.go
+++ b/internal/core/forward/events_test.go
@@ -54,7 +54,7 @@ func TestForwardManager_GetAllSessions(t *testing.T) {
 	_, _ = fm.AddRule(core.ForwardRule{Name: "fwd1", Host: "server1", Type: core.Dynamic, LocalPort: 1080})
 	_, _ = fm.AddRule(core.ForwardRule{Name: "fwd2", Host: "server1", Type: core.Dynamic, LocalPort: 1081})
 
-	_ = fm.StartForward("fwd1")
+	_ = fm.StartForward("fwd1", nil)
 
 	sessions := fm.GetAllSessions()
 	if len(sessions) != 2 {
@@ -87,7 +87,7 @@ func TestForwardManager_Subscribe_MultipleSubscribers(t *testing.T) {
 	ch2 := fm.Subscribe()
 
 	_, _ = fm.AddRule(core.ForwardRule{Name: "web", Host: "server1", Type: core.Dynamic, LocalPort: 1080})
-	_ = fm.StartForward("web")
+	_ = fm.StartForward("web", nil)
 
 	for _, ch := range []<-chan core.ForwardEvent{ch1, ch2} {
 		select {

--- a/internal/core/forward/forward_mock_test.go
+++ b/internal/core/forward/forward_mock_test.go
@@ -15,13 +15,14 @@ import (
 // --- Mock SSHManager for ForwardManager tests ---
 
 type mockSSHManager struct {
-	mu          sync.RWMutex
-	hosts       map[string]core.SSHHost
-	connections map[string]*ssh.Client
-	sshConns    map[string]core.SSHConnection
-	connected   map[string]bool
-	connectErr  error
-	subscribers []chan core.SSHEvent
+	mu              sync.RWMutex
+	hosts           map[string]core.SSHHost
+	connections     map[string]*ssh.Client
+	sshConns        map[string]core.SSHConnection
+	connected       map[string]bool
+	connectErr      error
+	connectWithCbFn func(hostName string, cb core.CredentialCallback) error
+	subscribers     []chan core.SSHEvent
 }
 
 func newMockSSHManager() *mockSSHManager {
@@ -57,6 +58,9 @@ func (m *mockSSHManager) Connect(hostName string) error {
 }
 
 func (m *mockSSHManager) ConnectWithCallback(hostName string, cb core.CredentialCallback) error {
+	if m.connectWithCbFn != nil {
+		return m.connectWithCbFn(hostName, cb)
+	}
 	return m.Connect(hostName)
 }
 

--- a/internal/core/forward/lifecycle.go
+++ b/internal/core/forward/lifecycle.go
@@ -11,7 +11,8 @@ import (
 )
 
 // StartForward はフォワーディングセッションを開始する。
-func (m *forwardManager) StartForward(ruleName string) error {
+// cb が非 nil の場合、SSH 接続にクレデンシャルコールバックを使用する。
+func (m *forwardManager) StartForward(ruleName string, cb core.CredentialCallback) error {
 	m.mu.Lock()
 	rule, exists := m.rules[ruleName]
 	if !exists {
@@ -25,9 +26,9 @@ func (m *forwardManager) StartForward(ruleName string) error {
 	}
 	m.mu.Unlock()
 
-	// SSH 接続を確認（必要に応じて接続）
+	// SSH 接続を確認（必要に応じてコールバック付きで接続）
 	if !m.sshManager.IsConnected(rule.Host) {
-		if err := m.sshManager.Connect(rule.Host); err != nil {
+		if err := m.sshManager.ConnectWithCallback(rule.Host, cb); err != nil {
 			return fmt.Errorf("failed to connect to host %s: %w", rule.Host, err)
 		}
 	}

--- a/internal/core/forward/lifecycle_stop_test.go
+++ b/internal/core/forward/lifecycle_stop_test.go
@@ -39,8 +39,8 @@ func TestForwardManager_StopAllForwards(t *testing.T) {
 	_, _ = fm.AddRule(core.ForwardRule{Name: "fwd1", Host: "server1", Type: core.Dynamic, LocalPort: 1080})
 	_, _ = fm.AddRule(core.ForwardRule{Name: "fwd2", Host: "server1", Type: core.Dynamic, LocalPort: 1081})
 
-	_ = fm.StartForward("fwd1")
-	_ = fm.StartForward("fwd2")
+	_ = fm.StartForward("fwd1", nil)
+	_ = fm.StartForward("fwd2", nil)
 
 	if err := fm.StopAllForwards(); err != nil {
 		t.Fatalf("StopAllForwards() error = %v", err)
@@ -67,7 +67,7 @@ func TestForwardManager_DeleteRule_StopsActive(t *testing.T) {
 	fm := NewForwardManager(sm)
 
 	_, _ = fm.AddRule(core.ForwardRule{Name: "web", Host: "server1", Type: core.Dynamic, LocalPort: 1080})
-	_ = fm.StartForward("web")
+	_ = fm.StartForward("web", nil)
 
 	if err := fm.DeleteRule("web"); err != nil {
 		t.Fatalf("DeleteRule() error = %v", err)
@@ -94,7 +94,7 @@ func TestForwardManager_Close(t *testing.T) {
 	events := fm.Subscribe()
 
 	_, _ = fm.AddRule(core.ForwardRule{Name: "web", Host: "server1", Type: core.Dynamic, LocalPort: 1080})
-	_ = fm.StartForward("web")
+	_ = fm.StartForward("web", nil)
 
 	// drain started event
 	select {
@@ -129,7 +129,7 @@ func TestForwardManager_StartForward_ListenerError(t *testing.T) {
 		Name: "web", Host: "server1", Type: core.Local, LocalPort: 8080, RemoteHost: "localhost", RemotePort: 80,
 	})
 
-	err := fm.StartForward("web")
+	err := fm.StartForward("web", nil)
 	if err == nil {
 		t.Fatal("StartForward() should return error when listener fails")
 	}
@@ -149,7 +149,7 @@ func TestForwardManager_StopForward_ClosesListener(t *testing.T) {
 	fm := NewForwardManager(sm)
 
 	_, _ = fm.AddRule(core.ForwardRule{Name: "web", Host: "server1", Type: core.Dynamic, LocalPort: 1080})
-	_ = fm.StartForward("web")
+	_ = fm.StartForward("web", nil)
 	_ = fm.StopForward("web")
 
 	ml.mu.Lock()

--- a/internal/core/forward/lifecycle_test.go
+++ b/internal/core/forward/lifecycle_test.go
@@ -14,7 +14,7 @@ func TestForwardManager_StartForward_RuleNotFound(t *testing.T) {
 	sm := newMockSSHManager()
 	fm := NewForwardManager(sm)
 
-	err := fm.StartForward("nonexistent")
+	err := fm.StartForward("nonexistent", nil)
 	if err == nil {
 		t.Fatal("StartForward() should return error for nonexistent rule")
 	}
@@ -29,10 +29,61 @@ func TestForwardManager_StartForward_ConnectError(t *testing.T) {
 		Name: "web", Host: "server1", Type: core.Local, LocalPort: 8080, RemoteHost: "localhost", RemotePort: 80,
 	})
 
-	err := fm.StartForward("web")
+	err := fm.StartForward("web", nil)
 	if err == nil {
 		t.Fatal("StartForward() should return error when SSH connect fails")
 	}
+}
+
+// TestForwardManager_StartForward_UsesCallbackForConnect は、
+// StartForward にコールバックを渡した場合、未接続ホストへの接続に
+// ConnectWithCallback（コールバック付き）が使用されることを検証する。
+// これは Issue #20 の回帰テスト: 以前は Connect（コールバックなし）が使用され、
+// パスワード認証が必要なホストへの接続が失敗していた。
+func TestForwardManager_StartForward_UsesCallbackForConnect(t *testing.T) {
+	sm := newMockSSHManager()
+	mockConn := &mockSSHConnection{
+		client:  nil,
+		isAlive: true,
+		localForwardF: func(ctx context.Context, localPort int, remoteAddr string) (net.Listener, error) {
+			return newMockListener(), nil
+		},
+	}
+
+	// Connect（コールバックなし）は認証エラーを返す
+	sm.connectErr = fmt.Errorf("authentication required: no authentication methods available")
+
+	// ConnectWithCallback はコールバック付きなら成功する
+	var receivedCb core.CredentialCallback
+	sm.connectWithCbFn = func(hostName string, cb core.CredentialCallback) error {
+		receivedCb = cb
+		sm.mu.Lock()
+		sm.connected[hostName] = true
+		sm.sshConns[hostName] = mockConn
+		sm.mu.Unlock()
+		return nil
+	}
+
+	fm := NewForwardManager(sm)
+	_, _ = fm.AddRule(core.ForwardRule{
+		Name: "web", Host: "server1", Type: core.Local, LocalPort: 8080, RemoteHost: "localhost", RemotePort: 80,
+	})
+
+	// コールバック付きで StartForward を呼び出す
+	cb := func(req core.CredentialRequest) (core.CredentialResponse, error) {
+		return core.CredentialResponse{Value: "password123"}, nil
+	}
+	err := fm.StartForward("web", cb)
+	if err != nil {
+		t.Fatalf("StartForward() with callback should succeed, got error: %v", err)
+	}
+
+	// ConnectWithCallback にコールバックが渡されたことを確認
+	if receivedCb == nil {
+		t.Fatal("ConnectWithCallback should have received a non-nil callback")
+	}
+
+	fm.Close()
 }
 
 func TestForwardManager_StartForward_Local(t *testing.T) {
@@ -53,7 +104,7 @@ func TestForwardManager_StartForward_Local(t *testing.T) {
 
 	events := fm.Subscribe()
 
-	if err := fm.StartForward("web"); err != nil {
+	if err := fm.StartForward("web", nil); err != nil {
 		t.Fatalf("StartForward() error = %v", err)
 	}
 
@@ -86,7 +137,7 @@ func TestForwardManager_StartForward_Local(t *testing.T) {
 	}
 
 	// 二重起動はエラー
-	err = fm.StartForward("web")
+	err = fm.StartForward("web", nil)
 	if err == nil {
 		t.Fatal("StartForward() should return error for already active forward")
 	}
@@ -130,7 +181,7 @@ func TestForwardManager_StartForward_Remote(t *testing.T) {
 		Name: "remote-web", Host: "server1", Type: core.Remote, LocalPort: 3000, RemoteHost: "0.0.0.0", RemotePort: 80,
 	})
 
-	if err := fm.StartForward("remote-web"); err != nil {
+	if err := fm.StartForward("remote-web", nil); err != nil {
 		t.Fatalf("StartForward() error = %v", err)
 	}
 
@@ -161,7 +212,7 @@ func TestForwardManager_StartForward_Dynamic(t *testing.T) {
 		Name: "socks", Host: "server1", Type: core.Dynamic, LocalPort: 1080,
 	})
 
-	if err := fm.StartForward("socks"); err != nil {
+	if err := fm.StartForward("socks", nil); err != nil {
 		t.Fatalf("StartForward() error = %v", err)
 	}
 

--- a/internal/core/forward/manager_rule_test.go
+++ b/internal/core/forward/manager_rule_test.go
@@ -77,7 +77,7 @@ func TestForwardManager_DeleteRule_Concurrent(t *testing.T) {
 	fm := NewForwardManager(sm)
 
 	_, _ = fm.AddRule(core.ForwardRule{Name: "web", Host: "server1", Type: core.Dynamic, LocalPort: 1080})
-	_ = fm.StartForward("web")
+	_ = fm.StartForward("web", nil)
 
 	var wg sync.WaitGroup
 	wg.Add(2)

--- a/internal/daemon/daemon_state.go
+++ b/internal/daemon/daemon_state.go
@@ -44,7 +44,7 @@ func (d *Daemon) restoreState() {
 	}
 
 	for _, rule := range state.ActiveForwards {
-		if err := d.fwdMgr.StartForward(rule.Name); err != nil {
+		if err := d.fwdMgr.StartForward(rule.Name, nil); err != nil {
 			slog.Warn("failed to restore forward", "rule", rule.Name, "error", err)
 		}
 	}

--- a/internal/ipc/handler/handler_forward.go
+++ b/internal/ipc/handler/handler_forward.go
@@ -83,23 +83,15 @@ func (h *Handler) forwardStart(clientID string, params json.RawMessage) (any, *p
 		return nil, err
 	}
 
-	// ホスト未接続の場合、クレデンシャルコールバック付きで事前接続する。
-	// これにより forward.start でパスワード認証もサポートされる。
-	// 注意: StartForward 内にも Connect のフォールバックがあるが、
-	// そちらはコールバックなしのため、パスワード認証が必要な場合は
-	// ここでの事前接続が必須。
+	// クレデンシャルコールバックを StartForward に渡す。
+	// StartForward 内で SSH 未接続時にコールバック付きで接続するため、
+	// パスワード認証や keyboard-interactive 認証もサポートされる。
 	session, err := h.fwdMgr.GetSession(p.Name)
 	if err != nil {
 		return nil, protocol.ToRPCError(err, protocol.InternalError)
 	}
-	if !h.sshMgr.IsConnected(session.Rule.Host) {
-		cb := h.buildCredentialCallback(clientID, session.Rule.Host)
-		if err := h.sshMgr.ConnectWithCallback(session.Rule.Host, cb); err != nil {
-			return nil, protocol.ToRPCError(err, protocol.InternalError)
-		}
-	}
-
-	if err := h.fwdMgr.StartForward(p.Name); err != nil {
+	cb := h.buildCredentialCallback(clientID, session.Rule.Host)
+	if err := h.fwdMgr.StartForward(p.Name, cb); err != nil {
 		return nil, protocol.ToRPCError(err, protocol.InternalError)
 	}
 

--- a/internal/ipc/handler/handler_forward_test.go
+++ b/internal/ipc/handler/handler_forward_test.go
@@ -222,22 +222,14 @@ func TestHandler_ForwardDelete_SavesConfig(t *testing.T) {
 	}
 }
 
-func TestHandler_ForwardStart_PreConnectsWithCallback(t *testing.T) {
-	h, sshMgr, fwdMgr, _ := newTestHandler()
+// TestHandler_ForwardStart_PassesCallbackToStartForward は、
+// handler がクレデンシャルコールバックを StartForward に渡すことを検証する。
+// これにより、StartForward 内で SSH 接続が必要な場合にパスワード認証がサポートされる。
+// Issue #20 の回帰テスト。
+func TestHandler_ForwardStart_PassesCallbackToStartForward(t *testing.T) {
+	h, _, fwdMgr, _ := newTestHandler()
 	sender := &mockNotificationSender{}
 	h.SetSender(sender)
-
-	// ホストは未接続
-	sshMgr.connected = map[string]bool{"prod": false}
-
-	// ConnectWithCallback が呼ばれたことを記録
-	var cbWasNonNil bool
-	sshMgr.connectWithCbFn = func(hostName string, cb core.CredentialCallback) error {
-		cbWasNonNil = cb != nil
-		// 接続成功をシミュレート
-		sshMgr.connected[hostName] = true
-		return nil
-	}
 
 	// セッション情報にルールを追加（GetSession で Host を取得するため）
 	fwdMgr.sessions = append(fwdMgr.sessions, core.ForwardSession{
@@ -251,7 +243,7 @@ func TestHandler_ForwardStart_PreConnectsWithCallback(t *testing.T) {
 		t.Fatalf("unexpected error: %v", rpcErr)
 	}
 
-	if !cbWasNonNil {
-		t.Error("forwardStart should call ConnectWithCallback with non-nil callback when sender is set")
+	if fwdMgr.lastStartCb == nil {
+		t.Error("forwardStart should pass non-nil CredentialCallback to StartForward")
 	}
 }

--- a/internal/ipc/handler/handler_mock_test.go
+++ b/internal/ipc/handler/handler_mock_test.go
@@ -101,6 +101,7 @@ type mockForwardManager struct {
 	stopAllErr    error
 	stopAllCalled bool
 	sessionErr    error
+	lastStartCb   core.CredentialCallback // StartForward に渡されたコールバックを記録
 }
 
 func (m *mockForwardManager) AddRule(rule core.ForwardRule) (string, error) {
@@ -135,7 +136,8 @@ func (m *mockForwardManager) GetRulesByHost(hostName string) []core.ForwardRule 
 	return result
 }
 
-func (m *mockForwardManager) StartForward(ruleName string) error {
+func (m *mockForwardManager) StartForward(ruleName string, cb core.CredentialCallback) error {
+	m.lastStartCb = cb
 	if m.startErr != nil {
 		return m.startErr
 	}


### PR DESCRIPTION
## Summary
- `StartForward` のインターフェースに `CredentialCallback` パラメータを追加し、SSH 接続時にコールバックを伝播するように変更
- handler の事前接続ロジック（`IsConnected` → `ConnectWithCallback`）を削除し、コールバックを `StartForward` に直接渡す設計に一本化
- TOCTOU（Time-of-Check to Time-of-Use）レースコンディションを構造的に解消

Closes #20

## Test plan
- [x] `TestForwardManager_StartForward_UsesCallbackForConnect` — 未接続ホストへの接続時にコールバックが `ConnectWithCallback` に渡されることを検証（回帰テスト）
- [x] `TestHandler_ForwardStart_PassesCallbackToStartForward` — handler が `StartForward` に非 nil コールバックを渡すことを検証（回帰テスト）
- [x] 既存テスト全パス（race detector 付き）
- [ ] パスワード認証が必要なホストで TUI から forward.start を実行し、認証が成功することを手動確認