### PR TITLE
docs: ドキュメント乖離レポート(#46)の修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ tui:
   theme:
     base: "dark"           # "dark" | "light"
     accent: "violet"       # "violet" | "blue" | "green" | "cyan" | "orange"
+
+update_check:
+  enabled: true            # false to disable update checks
+  interval: "24h"          # check interval
 ```
 
 ## Host Key Verification

--- a/README_ja.md
+++ b/README_ja.md
@@ -142,6 +142,10 @@ tui:
   theme:
     base: "dark"           # "dark" | "light"
     accent: "violet"       # "violet" | "blue" | "green" | "cyan" | "orange"
+
+update_check:
+  enabled: true            # false でアップデートチェックを無効化
+  interval: "24h"          # チェック間隔
 ```
 
 ## ホスト鍵検証

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -792,7 +792,7 @@ type DaemonShutdownResult struct {
 ```go
 // version.check
 type VersionCheckParams struct{}
-type VersionCheckRPCResult struct {
+type VersionCheckResult struct {
     CurrentVersion  string `json:"current_version"`            // 現在のバージョン（デーモンのビルドバージョン）
     LatestVersion   string `json:"latest_version,omitempty"`   // 最新リリースバージョン
     UpdateAvailable bool   `json:"update_available"`           // 更新があるか
@@ -915,4 +915,4 @@ type CredentialResponseResult struct {
 | 2.5 | 2026-03-01 | config.yaml に `tui.theme` セクション追加、Config に TUIConfig/ThemeConfig 型追加、IPC 型に TUIInfo/ThemeInfo/TUIUpdateInfo/ThemeUpdateInfo 追加 | #34 TUI カラーテーマ機能 |
 | 2.6 | 2026-03-01 | DaemonStatusResult に Version フィールドを追加 | #36 バージョン不一致検出 |
 | 2.7 | 2026-03-01 | Config/ConfigGetResult/ConfigUpdateParams に Language フィールド追加、DaemonShutdownParams に Purge フィールド追加、PromptInfo→PromptData 型名統一、CredentialRequestNotification.Type を string 型に修正、forward.stopAll 型定義追加 | ドキュメント乖離修正 (#40) |
-| 3.0 | 2026-03-04 | config.yaml に update_check セクション追加、Config に UpdateCheckConfig 型追加、VersionCheckResult 内部モデル追加、IPC 型に VersionCheckRPCResult/UpdateCheckInfo/UpdateCheckUpdateInfo 追加 | #44 最新バージョンチェック機能 |
+| 3.0 | 2026-03-04 | config.yaml に update_check セクション追加、Config に UpdateCheckConfig 型追加、VersionCheckResult 内部モデル追加、IPC 型に VersionCheckResult/UpdateCheckInfo/UpdateCheckUpdateInfo 追加 | #44 最新バージョンチェック機能 |

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -323,6 +323,7 @@ graph TD
         PI["PromptInput"]
         CD["ConfirmDialog"]
         PW["PasswordInput"]
+        ID["InfoDialog"]
     end
 
     subgraph Atoms
@@ -489,7 +490,7 @@ moleport/
 │   ├── ipc/                           # IPC 通信層（ベース）
 │   │   ├── server.go                  # IPCServer（JSON-RPC サーバー）
 │   │   ├── broker.go                  # EventBroker（イベント配信）
-│   │   ├── protocol/                  # JSON-RPC メッセージ型定義（9 ファイル）
+│   │   ├── protocol/                  # JSON-RPC メッセージ型定義（10 ファイル）
 │   │   │   ├── protocol.go            # コアプロトコル（Request/Response/Error）
 │   │   │   ├── convert.go             # コアエラー・型の RPC 変換
 │   │   │   ├── protocol_host.go       # ホスト管理メッセージ型
@@ -499,7 +500,8 @@ moleport/
 │   │   │   ├── protocol_config.go     # 設定メッセージ型
 │   │   │   ├── protocol_daemon.go     # デーモンメッセージ型
 │   │   │   ├── protocol_version.go   # バージョンチェックメッセージ型
-│   │   │   └── protocol_events.go     # イベント・通知メッセージ型
+│   │   │   ├── protocol_events.go     # イベント・通知メッセージ型
+│   │   │   └── wire_constants.go      # IPC ワイヤーフォーマット定数
 │   │   ├── handler/                   # RPC メソッドハンドラ
 │   │   │   ├── handler.go             # ディスパッチャ・初期化
 │   │   │   ├── handler_host.go        # host.list, host.reload
@@ -545,6 +547,8 @@ moleport/
 │   │   │   ├── app_lifecycle.go       # ライフサイクル管理
 │   │   │   ├── app_theme.go           # テーマ選択コマンド
 │   │   │   ├── app_version.go         # バージョンチェック
+│   │   │   ├── app_update.go          # アップデート通知 UI メッセージハンドラ
+│   │   │   ├── app_update_check.go    # 最新バージョンチェック Cmd
 │   │   │   └── convert.go             # IPC/コア型変換
 │   │   ├── theme/                     # テーマシステム
 │   │   │   ├── theme.go               # Theme 型定義、Current()/Apply()
@@ -560,7 +564,8 @@ moleport/
 │   │   │   ├── setuppanel_view.go     # SetupPanel View レンダリング
 │   │   │   ├── forwardpanel.go
 │   │   │   ├── logpanel.go
-│   │   │   └── statusbar.go
+│   │   │   ├── statusbar.go
+│   │   │   └── themegrid.go           # ThemeGrid コンポーネント
 │   │   └── pages/
 │   │       ├── dashboard.go           # DashboardPage（Init/Update/View）
 │   │       ├── dashboard_layout.go    # レイアウト計算・フォーカス管理

--- a/docs/components/overview.md
+++ b/docs/components/overview.md
@@ -1282,6 +1282,31 @@ func (g ThemeGrid) View() string
 func (g ThemeGrid) SelectedPresetID() string
 ```
 
+### InfoDialog (`molecules/infodialog.go`)
+
+OK ボタンのみの情報ダイアログ Molecule。アップデート通知など、ユーザーへの情報表示に使用する。
+
+#### 責務
+
+- メッセージテキストの表示
+- OK ボタン（Enter / Esc / O キー）で閉じる操作
+- 閉じたときに `InfoDismissedMsg` を発行
+
+#### インターフェース
+
+```go
+type InfoDialog struct {
+    message string
+}
+
+type InfoDismissedMsg struct{}
+
+func NewInfoDialog(message string) InfoDialog
+func (m InfoDialog) Init() tea.Cmd
+func (m InfoDialog) Update(msg tea.Msg) (InfoDialog, tea.Cmd)
+func (m InfoDialog) View() string
+```
+
 ### Organisms
 
 SetupPanel / ForwardPanel / LogPanel / StatusBar の構造は維持。
@@ -1344,7 +1369,7 @@ ForwardPanel / SetupPanel / LogPanel（Organisms）
 StatusBar（Organism）
   責務: 背景色付きスタイルを自身で適用
 
-ConfirmDialog / PasswordInput（Molecules）
+ConfirmDialog / PasswordInput / InfoDialog（Molecules）
   責務: 自身のボーダー描画（常にフォーカス状態）
 ```
 
@@ -1359,6 +1384,7 @@ ConfirmDialog / PasswordInput（Molecules）
 | **StatusBar** | `organisms/statusbar.go` | View 内で `StatusBarStyle`（背景色付き）を自身で適用 |
 | **ConfirmDialog** | `molecules/confirmdialog.go` | View 内で `FocusedBorder` を自身で適用 |
 | **PasswordInput** | `molecules/passwordinput.go` | View 内で `FocusedBorder` を自身で適用 |
+| **InfoDialog** | `molecules/infodialog.go` | View 内で `FocusedBorder` を自身で適用 |
 
 #### ボーダーのインラインタイトル
 
@@ -1411,6 +1437,7 @@ return border.
 | **StatusBar** | `organisms/statusbar.go` | 統計テキストを `i18n.T("tui.statusbar.*")` に置き換え |
 | **ConfirmDialog** | `molecules/confirmdialog.go` | 「はい」「いいえ」を `i18n.T("tui.confirm.*")` に置き換え |
 | **PasswordInput** | `molecules/passwordinput.go` | プロンプトテキストを `i18n.T()` に置き換え |
+| **InfoDialog** | `molecules/infodialog.go` | OK ボタンテキストを `i18n.T("tui.update.ok")` に置き換え |
 | **app_version** | `app/app_version.go` | バージョン不一致メッセージを `i18n.T()` に置き換え |
 | **Config** | `core/types_models.go` | `Config` 構造体に `Language string` フィールドを追加 |
 


### PR DESCRIPTION
Closes #46

## Summary
- `docs/architecture/overview.md`: ディレクトリ構成に `app_update.go`, `app_update_check.go`, `themegrid.go`, `wire_constants.go` を追記。Atomic Design 図の Molecules に `InfoDialog` を追加
- `docs/architecture/data-model.md`: `VersionCheckRPCResult` → `VersionCheckResult` に型名を修正（実装と一致）
- `docs/components/overview.md`: InfoDialog コンポーネント仕様を追加。ボーダー責務・i18n テーブルにも追記
- `README.md` / `README_ja.md`: 設定例に `update_check` セクションを追加

## 手動チェック項目

### 品質
- [x] lint / format がパスする
- [x] テストがすべてパスする