### PR TITLE
fix: Close() でプロセスグループ全体を Kill (#56)

### DIFF
--- a/internal/infra/proxycommand/proxycommand.go
+++ b/internal/infra/proxycommand/proxycommand.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 )
 
@@ -43,7 +44,7 @@ func (c *conn) Close() error {
 		_ = c.stdout.Close()
 
 		if c.cmd.Process != nil {
-			_ = c.cmd.Process.Kill()
+			_ = syscall.Kill(-c.cmd.Process.Pid, syscall.SIGKILL)
 		}
 		// cmd.Wait() は goroutine 側で実行される。done チャネルで完了を待機する。
 		<-c.done
@@ -69,6 +70,7 @@ func (c *conn) SetWriteDeadline(_ time.Time) error { return nil }
 // Dial は ProxyCommand を起動し、その stdin/stdout を net.Conn として返す。
 func Dial(command string) (net.Conn, error) {
 	cmd := exec.Command("sh", "-c", command) //nolint:gosec // ProxyCommand は SSH config 由来のユーザー設定値
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {


### PR DESCRIPTION
## Summary

- `Dial()` で `Setpgid=true` を設定し、子プロセスを同一プロセスグループに配置
- `Close()` で `syscall.Kill(-pid, SIGKILL)` によりプロセスグループ全体を終了
- `sh` の子プロセスが残存して `cmd.Wait()` がブロックする問題を解消

## Bug Details

- **症状**: `TestConn_CloseTerminatesProcess` が `-race` 付きで間欠的に10分タイムアウト
- **原因**: `cmd.Process.Kill()` が `sh` プロセスのみに SIGKILL → 子プロセス (`sleep`) が stdout パイプを保持 → `cmd.Wait()` 内の `awaitGoroutines` がブロック
- **修正**: プロセスグループ全体を Kill することで子プロセスも確実に終了

Closes #56

## Test Plan

- [x] `go test -race ./internal/infra/proxycommand/ -count=10` が安定 PASS
- [x] 全パッケージの `-race` テストが PASS（pre-push hook）
- [x] golangci-lint PASS
- [x] linterly PASS