### PR TITLE
docs: ドキュメント乖離5件を修正 #70

### DIFF
--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -425,11 +425,19 @@ type ForwardSession struct {
     LastError      string        // 最後のエラーメッセージ
 }
 
+// フォワード復元結果
+type ForwardRestoreResult struct {
+    RuleName string // ルール名
+    OK       bool   // 復元成功フラグ
+    Error    string // エラーメッセージ（失敗時）
+}
+
 // バージョンチェック結果（デーモンがメモリにキャッシュ）
 type VersionCheckResult struct {
-    LatestVersion string    // 最新リリースのバージョン（例: "v0.2.0"）
-    ReleaseURL    string    // GitHub リリースページの URL
-    CheckedAt     time.Time // チェック実行日時
+    LatestVersion   string    // 最新リリースのバージョン（例: "v0.2.0"）
+    ReleaseURL      string    // GitHub リリースページの URL
+    CheckedAt       time.Time // チェック実行日時
+    UpdateAvailable bool      // アップデートが利用可能か
 }
 
 ```

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -514,7 +514,8 @@ moleport/
 │   │   │   ├── handler_version.go    # version.check
 │   │   │   └── handler_events.go      # events.subscribe/unsubscribe
 │   │   └── client/                    # JSON-RPC クライアント
-│   │       └── client.go              # IPCClient（メソッド呼び出し・イベント受信）
+│   │       ├── client.go              # IPCClient（メソッド呼び出し・イベント受信）
+│   │       └── client_credential.go   # クレデンシャルハンドラ（設定・応答処理）
 │   ├── i18n/                           # 多言語対応（i18n）
 │   │   ├── i18n.go                    # Localizer（翻訳テキスト取得・SetLang）
 │   │   ├── resolver.go                # Resolver（言語解決: config → 環境変数 → デフォルト）
@@ -564,9 +565,10 @@ moleport/
 │   │   ├── atoms/
 │   │   ├── molecules/
 │   │   ├── organisms/
-│   │   │   ├── setuppanel.go          # SetupPanel コア
-│   │   │   ├── setuppanel_update.go   # SetupPanel Update ハンドラ
-│   │   │   ├── setuppanel_view.go     # SetupPanel View レンダリング
+│   │   │   ├── setuppanel/            # SetupPanel コンポーネント（サブディレクトリ）
+│   │   │   │   ├── setuppanel.go      # SetupPanel コア
+│   │   │   │   ├── setuppanel_update.go # SetupPanel Update ハンドラ
+│   │   │   │   └── setuppanel_view.go # SetupPanel View レンダリング
 │   │   │   ├── forwardpanel.go
 │   │   │   ├── logpanel.go
 │   │   │   ├── statusbar.go
@@ -597,7 +599,8 @@ moleport/
 │   │   │   ├── lifecycle.go           # Start/Stop ライフサイクル
 │   │   │   ├── bridge.go             # 接続ブリッジ（accept/dial/copy）
 │   │   │   ├── reconnect.go          # フォワード復元（MarkReconnecting/RestoreForwards/FailReconnecting）
-│   │   │   └── events.go             # セッション照会・イベント管理
+│   │   │   ├── events.go             # セッション照会・イベント管理
+│   │   │   └── forward_helper.go     # ヘルパー関数（openListener 等）
 │   │   └── update/                    # バージョンチェック・セルフアップデート
 │   │       ├── checker.go            # VersionChecker（GitHub API・キャッシュ・比較）
 │   │       └── updater.go            # Updater（ダウンロード・検証・バイナリ置換）

--- a/docs/components/overview.md
+++ b/docs/components/overview.md
@@ -56,7 +56,7 @@ graph TD
         Dashboard["pages/dashboard.go"]
         ThemePg["pages/theme.go"]
         LangPg["pages/lang.go"]
-        SP["organisms/setuppanel.go"]
+        SP["organisms/setuppanel/<br/>setuppanel.go"]
         FP["organisms/forwardpanel.go"]
         LP["organisms/logpanel.go"]
         SB["organisms/statusbar.go"]


### PR DESCRIPTION
Closes #70

## Summary
- SetupPanel のパス参照を `organisms/setuppanel/` サブディレクトリに修正（overview.md, components/overview.md）
- `forward_helper.go` をディレクトリ構成図に追加（overview.md）
- `client_credential.go` をディレクトリ構成図に追加（overview.md）
- `VersionCheckResult` に `UpdateAvailable` フィールドを追加（data-model.md）
- `ForwardRestoreResult` 型を内部データモデルに追加（data-model.md）

## 手動チェック項目

### 品質
- [x] lint / format がパスする
- [x] テストがすべてパスする