### PR TITLE
fix: パスワード認証時の IPC readLoop デッドロックを解消 #81

### DIFF
--- a/internal/cli/connect_cmd.go
+++ b/internal/cli/connect_cmd.go
@@ -21,7 +21,7 @@ func RunConnect(configDir string, args []string) {
 
 	host := args[0]
 	client := ConnectDaemon(configDir)
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	// クレデンシャルハンドラーを設定
 	client.SetCredentialHandler(newCLICredentialHandler())

--- a/internal/cli/daemoncmd/daemoncmd.go
+++ b/internal/cli/daemoncmd/daemoncmd.go
@@ -69,7 +69,7 @@ func runDaemonStop(configDir string, args []string) {
 	if err != nil {
 		cli.ExitError("%s", i18n.T("cli.daemon.connect_failed", map[string]any{"Error": err}))
 	}
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	ctx, cancel := cli.CallCtx()
 	defer cancel()
@@ -119,7 +119,7 @@ func runDaemonStatus(configDir string) {
 	if err != nil {
 		cli.ExitError("%s", i18n.T("cli.daemon.connect_failed", map[string]any{"Error": err}))
 	}
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	ctx, cancel := cli.CallCtx()
 	defer cancel()

--- a/internal/ipc/server.go
+++ b/internal/ipc/server.go
@@ -240,26 +240,29 @@ func (s *IPCServer) readLoop(c *clientConn) {
 
 		// ID が nil の場合は通知（レスポンス不要）
 		if req.ID == nil {
-			s.handler(c.id, req.Method, req.Params)
+			go func(method string, params json.RawMessage) {
+				_, _ = s.handler(c.id, method, params)
+			}(req.Method, req.Params)
 			continue
 		}
 
-		result, rpcErr := s.handler(c.id, req.Method, req.Params)
-		if rpcErr != nil {
-			resp := protocol.NewErrorResponse(req.ID, rpcErr.Code, rpcErr.Message)
-			if err := c.send(resp); err != nil {
+		// リクエストを goroutine で非同期処理する。
+		// これにより readLoop がブロックされず、同一クライアントからの
+		// 後続リクエスト（例: credential.response）を読み取れる。
+		go func(id *int, method string, params json.RawMessage) {
+			result, rpcErr := s.handler(c.id, method, params)
+			if rpcErr != nil {
+				resp := protocol.NewErrorResponse(id, rpcErr.Code, rpcErr.Message)
+				_ = c.send(resp)
 				return
 			}
-			continue
-		}
 
-		resp, err := protocol.NewResponse(req.ID, result)
-		if err != nil {
-			resp = protocol.NewErrorResponse(req.ID, protocol.InternalError, "marshal result: "+err.Error())
-		}
-		if err := c.send(resp); err != nil {
-			return
-		}
+			resp, err := protocol.NewResponse(id, result)
+			if err != nil {
+				resp = protocol.NewErrorResponse(id, protocol.InternalError, "marshal result: "+err.Error())
+			}
+			_ = c.send(resp)
+		}(req.ID, req.Method, req.Params)
 	}
 }
 

--- a/internal/ipc/server_test.go
+++ b/internal/ipc/server_test.go
@@ -136,6 +136,82 @@ func TestServerClient_ConnectedClients(t *testing.T) {
 	waitFor(t, func() bool { return srv.ConnectedClients() == 0 })
 }
 
+// TestServerClient_ConcurrentCredentialExchange は、readLoop が同期的にハンドラーを
+// 呼び出している場合に発生するデッドロックを検証する回帰テスト（Issue #81）。
+//
+// シナリオ:
+//  1. クライアントが forward.start RPC を送信
+//  2. サーバーハンドラーが credential.request 通知を返送し、credential.response を待機
+//  3. クライアントが通知を受信し credential.response RPC を送信
+//  4. readLoop が同期的だと手順3のメッセージを読めずデッドロックする
+func TestServerClient_ConcurrentCredentialExchange(t *testing.T) {
+	// credential.response 用のチャネル（ハンドラー間でデータを受け渡す）
+	credCh := make(chan string, 1)
+
+	var srv *IPCServer
+
+	handler := func(clientID string, method string, params json.RawMessage) (any, *protocol.RPCError) {
+		switch method {
+		case "forward.start":
+			// credential.request 通知をクライアントに送信
+			notif := protocol.Notification{
+				JSONRPC: protocol.JSONRPCVersion,
+				Method:  "credential.request",
+				Params:  json.RawMessage(`{"request_id":"cr-1","type":"password","host":"test","prompt":"Password:"}`),
+			}
+			if err := srv.SendNotification(clientID, notif); err != nil {
+				return nil, &protocol.RPCError{Code: protocol.InternalError, Message: err.Error()}
+			}
+			// credential.response が来るまで待機（タイムアウト付き）
+			select {
+			case val := <-credCh:
+				return map[string]string{"password": val}, nil
+			case <-time.After(3 * time.Second):
+				return nil, &protocol.RPCError{Code: protocol.InternalError, Message: "credential timeout"}
+			}
+
+		case "credential.response":
+			var p struct {
+				RequestID string `json:"request_id"`
+				Value     string `json:"value"`
+			}
+			if err := json.Unmarshal(params, &p); err != nil {
+				return nil, &protocol.RPCError{Code: protocol.InvalidParams, Message: err.Error()}
+			}
+			credCh <- p.Value
+			return map[string]bool{"ok": true}, nil
+
+		default:
+			return nil, &protocol.RPCError{Code: protocol.MethodNotFound, Message: "not found"}
+		}
+	}
+
+	var sockPath string
+	srv, sockPath = startTestServer(t, handler)
+	client := connectTestClient(t, sockPath)
+	waitFor(t, func() bool { return srv.ConnectedClients() == 1 })
+
+	// クライアント側: credential.request 通知を受けたら credential.response を返す
+	client.SetCredentialHandler(func(req protocol.CredentialRequestNotification) (*protocol.CredentialResponseParams, error) {
+		return &protocol.CredentialResponseParams{
+			RequestID: req.RequestID,
+			Value:     "my-secret",
+		}, nil
+	})
+
+	// forward.start を呼び出し — デッドロックしなければ成功する
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var result map[string]string
+	if err := client.Call(ctx, "forward.start", map[string]string{"name": "test"}, &result); err != nil {
+		t.Fatalf("forward.start should succeed but got: %v", err)
+	}
+	if result["password"] != "my-secret" {
+		t.Errorf("password = %q, want %q", result["password"], "my-secret")
+	}
+}
+
 // waitFor は条件が満たされるまで最大 2 秒待つヘルパー。
 func waitFor(t *testing.T, cond func() bool) {
 	t.Helper()


### PR DESCRIPTION
## Summary

- IPC サーバーの `readLoop` が RPC ハンドラーを同期的に呼び出していたため、`forward.start` / `ssh.connect` のパスワード認証時に `credential.response` を読み取れずデッドロックが発生していた
- `readLoop` のハンドラー呼び出しを goroutine で非同期化し、同一クライアントからの後続リクエストを処理可能にした
- 既存の `defer client.Close()` の errcheck 違反（3箇所）も合わせて修正

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `internal/ipc/server.go` | readLoop のリクエスト処理を goroutine で非同期化 |
| `internal/ipc/server_test.go` | デッドロック再現の回帰テスト追加 |
| `internal/cli/connect_cmd.go` | 既存 errcheck 違反修正 |
| `internal/cli/daemoncmd/daemoncmd.go` | 既存 errcheck 違反修正（2箇所） |

## Test plan

- [x] 回帰テスト `TestServerClient_ConcurrentCredentialExchange` が修正前に失敗、修正後に成功することを確認
- [x] `go test ./internal/ipc/...` 全テスト通過
- [x] `go vet`, `golangci-lint` エラーなし
- [ ] パスワード認証が必要な SSH ホストに対して `forward.start` が成功することを手動確認
- [ ] 公開鍵認証（パスワード不要）のホストへの接続が影響を受けないことを確認